### PR TITLE
Test Account Components

### DIFF
--- a/src/features/account/tests/Login.test.tsx
+++ b/src/features/account/tests/Login.test.tsx
@@ -1,0 +1,181 @@
+import { BrowserRouter } from "react-router-dom"
+
+import { faker } from "@faker-js/faker"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import Login from "../Login"
+
+const firebaseAuth = require("firebase/auth")
+
+const email = faker.internet.email()
+const invalidEmail = faker.lorem.word(5)
+const password = faker.lorem.word(6)
+const invalidPassword = faker.lorem.word(5)
+const errorMessage = faker.lorem.sentence(5)
+const errorMessage2 = faker.lorem.sentence(4)
+
+const mockSignInWithEmailAndPassword = jest.fn()
+const mockSignInWithPopup = jest.fn()
+
+jest.mock("firebase/app", () => {
+  return {
+    initializeApp: jest.fn(),
+  }
+})
+
+jest.mock("firebase/auth", () => {
+  return {
+    getAuth: jest.fn(),
+    GoogleAuthProvider: jest.fn(),
+    signInWithEmailAndPassword: (...args: unknown[]) => {
+      mockSignInWithEmailAndPassword(...args)
+    },
+    signInWithPopup: (...args: unknown[]) => {
+      mockSignInWithPopup(...args)
+    },
+  }
+})
+
+jest.mock("firebase/firestore", () => {
+  return {
+    getFirestore: jest.fn(),
+  }
+})
+
+const component = (
+  <BrowserRouter>
+    <Login />
+  </BrowserRouter>
+)
+
+describe("Login", () => {
+  test("prevents submission and shows error if credentials are invalid", () => {
+    render(component)
+    const emailInput = screen.getByLabelText(/email/i)
+    expect(emailInput).toHaveFocus()
+    expect(emailInput).toHaveDisplayValue("")
+    expect(emailInput).toBeValid()
+    const passwordInput = screen.getByLabelText("Password")
+    expect(passwordInput).toHaveDisplayValue("")
+    expect(passwordInput).toBeValid()
+
+    // required errors displayed when user submits
+    userEvent.keyboard("{enter}")
+    expect(emailInput).toBeInvalid()
+    screen.getByText(/email is required/i)
+    expect(passwordInput).toBeInvalid()
+    screen.getByText(/password is required/i)
+
+    // type a value which is not an email
+    userEvent.type(emailInput, invalidEmail)
+
+    // errors cleared because input changed
+    expect(emailInput).toBeValid()
+    expect(screen.queryByText(/email is required/i)).toBeNull()
+    expect(passwordInput).toBeValid()
+    expect(screen.queryByText(/password is required/i)).toBeNull()
+
+    // invalid email error displayed when user submits
+    userEvent.keyboard("{enter}")
+    expect(emailInput).toBeInvalid()
+    screen.getByText(/invalid email/i)
+
+    // test password minimum length validation
+    userEvent.type(passwordInput, `${invalidPassword}{enter}`)
+    expect(passwordInput).toBeInvalid()
+    screen.getByText(/minimum password length is 6/i)
+
+    // none of the attempted submits were successful
+    expect(mockSignInWithEmailAndPassword).not.toHaveBeenCalled()
+    expect(mockSignInWithPopup).not.toHaveBeenCalled()
+  })
+
+  test("logs user in if credentials are valid", async () => {
+    render(component)
+    const submitButton = screen.getByRole("button", {
+      name: "Login",
+    })
+    userEvent.type(screen.getByLabelText(/email/i), email)
+    userEvent.type(screen.getByLabelText("Password"), password)
+    userEvent.click(submitButton)
+
+    // buttons disabled while submitting
+    expect(submitButton).toBeDisabled()
+    expect(
+      screen.getByRole("button", {
+        name: /login with google/i,
+      }),
+    ).toBeDisabled()
+    // hit enter to ensure no extra request is fired
+    userEvent.keyboard("{enter}")
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled()
+    })
+
+    // no unexpected call happened
+    expect(mockSignInWithPopup).not.toHaveBeenCalled()
+    expect(mockSignInWithEmailAndPassword).toHaveBeenCalledTimes(1)
+    // correct credentials passed to method
+    expect(mockSignInWithEmailAndPassword).toHaveBeenCalledWith(
+      undefined,
+      email,
+      password,
+    )
+  })
+
+  test("opens popup to log user in using google", async () => {
+    render(component)
+    const googleButton = screen.getByRole("button", {
+      name: /login with google/i,
+    })
+    userEvent.click(googleButton)
+
+    // type valid credentials to facilitate loading state test
+    userEvent.type(screen.getByLabelText(/email/i), email)
+    userEvent.type(screen.getByLabelText("Password"), password)
+
+    // buttons disabled while submitting
+    expect(googleButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Login" })).toBeDisabled()
+    // hit enter to ensure no extra request is fired
+    userEvent.keyboard("{enter}")
+
+    await waitFor(() => {
+      expect(googleButton).toBeEnabled()
+    })
+
+    // no unexpected call happened
+    expect(mockSignInWithEmailAndPassword).not.toHaveBeenCalled()
+    expect(mockSignInWithPopup).toHaveBeenCalledTimes(1)
+  })
+
+  test("shows error if one occurs", async () => {
+    jest
+      .spyOn(firebaseAuth, "signInWithEmailAndPassword")
+      .mockImplementation(() => {
+        throw Error(errorMessage)
+      })
+
+    jest.spyOn(firebaseAuth, "signInWithPopup").mockImplementation(() => {
+      throw Error(errorMessage2)
+    })
+
+    render(component)
+    userEvent.type(screen.getByLabelText(/email/i), email)
+    userEvent.type(screen.getByLabelText("Password"), `${password}{enter}`)
+
+    // error message displayed in alert
+    await screen.findByRole("alert")
+    screen.getByText(errorMessage)
+
+    // test Google error handling
+    userEvent.click(screen.getByRole("button", { name: /login with google/i }))
+    await screen.findByText(errorMessage2)
+
+    // user can hide alert
+    userEvent.click(screen.getByRole("button", { name: /close/i }))
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+})

--- a/src/features/account/tests/Register.test.tsx
+++ b/src/features/account/tests/Register.test.tsx
@@ -1,0 +1,194 @@
+import { BrowserRouter } from "react-router-dom"
+
+import { faker } from "@faker-js/faker"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import Register from "../Register"
+
+const firebaseAuth = require("firebase/auth")
+
+const username = faker.internet.userName()
+const email = faker.internet.email()
+const invalidEmail = faker.lorem.word(5)
+const password = faker.lorem.word(6)
+const invalidPassword = faker.lorem.word(5)
+const errorMessage = faker.lorem.sentence(5)
+const errorMessage2 = faker.lorem.sentence(4)
+
+const mockCreateUserWithEmailAndPassword = jest.fn()
+const mockSignInWithPopup = jest.fn()
+
+jest.mock("firebase/app", () => {
+  return {
+    initializeApp: jest.fn(),
+  }
+})
+
+jest.mock("firebase/auth", () => {
+  return {
+    getAuth: jest.fn(),
+    GoogleAuthProvider: jest.fn(),
+    createUserWithEmailAndPassword: (...args: unknown[]) => {
+      mockCreateUserWithEmailAndPassword(...args)
+    },
+    signInWithPopup: (...args: unknown[]) => {
+      mockSignInWithPopup(...args)
+    },
+  }
+})
+
+jest.mock("firebase/firestore", () => {
+  return {
+    getFirestore: jest.fn(),
+  }
+})
+
+const component = (
+  <BrowserRouter>
+    <Register />
+  </BrowserRouter>
+)
+
+describe("Register", () => {
+  test("prevents submission and shows error if credentials are invalid", () => {
+    render(component)
+    const usernameInput = screen.getByLabelText(/username/i)
+    expect(usernameInput).toHaveFocus()
+    expect(usernameInput).toHaveDisplayValue("")
+    expect(usernameInput).toBeValid()
+    const emailInput = screen.getByLabelText(/email/i)
+    expect(emailInput).toHaveDisplayValue("")
+    expect(emailInput).toBeValid()
+    const passwordInput = screen.getByLabelText("Password")
+    expect(passwordInput).toHaveDisplayValue("")
+    expect(passwordInput).toBeValid()
+
+    // required errors displayed when user submits
+    userEvent.keyboard("{enter}")
+    expect(usernameInput).toBeInvalid()
+    screen.getByText(/username is required/i)
+    expect(emailInput).toBeInvalid()
+    screen.getByText(/email is required/i)
+    expect(passwordInput).toBeInvalid()
+    screen.getByText(/password is required/i)
+
+    // type a value which is not an email
+    userEvent.type(emailInput, invalidEmail)
+
+    // errors cleared because input changed
+    expect(usernameInput).toBeValid()
+    expect(screen.queryByText(/username is required/i)).toBeNull()
+    expect(emailInput).toBeValid()
+    expect(screen.queryByText(/email is required/i)).toBeNull()
+    expect(passwordInput).toBeValid()
+    expect(screen.queryByText(/password is required/i)).toBeNull()
+
+    // invalid email error displayed when user submits
+    userEvent.keyboard("{enter}")
+    expect(emailInput).toBeInvalid()
+    screen.getByText(/invalid email/i)
+
+    // test password minimum length validation
+    userEvent.type(passwordInput, `${invalidPassword}{enter}`)
+    expect(passwordInput).toBeInvalid()
+    screen.getByText(/minimum password length is 6/i)
+
+    // none of the attempted submits were successful
+    expect(mockCreateUserWithEmailAndPassword).not.toHaveBeenCalled()
+    expect(mockSignInWithPopup).not.toHaveBeenCalled()
+  })
+
+  test("logs user in if credentials are valid", async () => {
+    render(component)
+    const submitButton = screen.getByRole("button", {
+      name: "Register",
+    })
+    userEvent.type(screen.getByLabelText(/username/i), username)
+    userEvent.type(screen.getByLabelText(/email/i), email)
+    userEvent.type(screen.getByLabelText("Password"), password)
+    userEvent.click(submitButton)
+
+    // buttons disabled while submitting
+    expect(submitButton).toBeDisabled()
+    expect(
+      screen.getByRole("button", {
+        name: /register with google/i,
+      }),
+    ).toBeDisabled()
+    // hit enter to ensure no extra request is fired
+    userEvent.keyboard("{enter}")
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled()
+    })
+
+    // no unexpected call happened
+    expect(mockSignInWithPopup).not.toHaveBeenCalled()
+    expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledTimes(1)
+    // correct credentials passed to method
+    expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledWith(
+      undefined,
+      email,
+      password,
+    )
+  })
+
+  test("opens popup to log user in using google", async () => {
+    render(component)
+    const googleButton = screen.getByRole("button", {
+      name: /register with google/i,
+    })
+    userEvent.click(googleButton)
+
+    // type valid credentials to facilitate loading state test
+    userEvent.type(screen.getByLabelText(/username/i), username)
+    userEvent.type(screen.getByLabelText(/email/i), email)
+    userEvent.type(screen.getByLabelText("Password"), password)
+
+    // buttons disabled while submitting
+    expect(googleButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Register" })).toBeDisabled()
+    // hit enter to ensure no extra request is fired
+    userEvent.keyboard("{enter}")
+
+    await waitFor(() => {
+      expect(googleButton).toBeEnabled()
+    })
+
+    // no unexpected call happened
+    expect(mockCreateUserWithEmailAndPassword).not.toHaveBeenCalled()
+    expect(mockSignInWithPopup).toHaveBeenCalledTimes(1)
+  })
+
+  test("shows error if one occurs", async () => {
+    jest
+      .spyOn(firebaseAuth, "createUserWithEmailAndPassword")
+      .mockImplementation(() => {
+        throw Error(errorMessage)
+      })
+
+    jest.spyOn(firebaseAuth, "signInWithPopup").mockImplementation(() => {
+      throw Error(errorMessage2)
+    })
+
+    render(component)
+    userEvent.type(screen.getByLabelText(/username/i), username)
+    userEvent.type(screen.getByLabelText(/email/i), email)
+    userEvent.type(screen.getByLabelText("Password"), `${password}{enter}`)
+
+    // error message displayed in alert
+    await screen.findByRole("alert")
+    screen.getByText(errorMessage)
+
+    // test Google error handling
+    userEvent.click(
+      screen.getByRole("button", { name: /register with google/i }),
+    )
+    await screen.findByText(errorMessage2)
+
+    // user can hide alert
+    userEvent.click(screen.getByRole("button", { name: /close/i }))
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+})

--- a/src/features/account/tests/ResetPassword.test.tsx
+++ b/src/features/account/tests/ResetPassword.test.tsx
@@ -36,19 +36,22 @@ jest.mock("firebase/firestore", () => {
   }
 })
 
+const component = (
+  <BrowserRouter>
+    <ResetPassword />
+  </BrowserRouter>
+)
+
 describe("ResetPassword", () => {
   test("prevents submission and shows error if email is invalid", () => {
-    render(
-      <BrowserRouter>
-        <ResetPassword />
-      </BrowserRouter>,
-    )
+    render(component)
     const emailInput = screen.getByLabelText(/email/i)
+    expect(emailInput).toHaveFocus()
     expect(emailInput).toHaveDisplayValue("")
     expect(emailInput).toBeValid()
 
     // required email error displayed when user submits
-    userEvent.type(emailInput, "{enter}")
+    userEvent.keyboard("{enter}")
     expect(emailInput).toBeInvalid()
     screen.getByText(/email is required/i)
 
@@ -60,7 +63,7 @@ describe("ResetPassword", () => {
     expect(screen.queryByText(/email is required/i)).toBeNull()
 
     // invalid email error displayed when user submits
-    userEvent.type(emailInput, "{enter}")
+    userEvent.keyboard("{enter}")
     expect(emailInput).toBeInvalid()
     screen.getByText(/invalid email/i)
 
@@ -69,22 +72,17 @@ describe("ResetPassword", () => {
   })
 
   test("sends password reset email and shows confirmation if email is valid", async () => {
-    render(
-      <BrowserRouter>
-        <ResetPassword />
-      </BrowserRouter>,
-    )
+    render(component)
     const submitButton = screen.getByRole("button", {
       name: /reset password/i,
     })
-    const emailInput = screen.getByLabelText(/email/i)
-    userEvent.type(emailInput, email)
+    userEvent.type(screen.getByLabelText(/email/i), email)
     userEvent.click(submitButton)
 
     // button disabled while submitting
     expect(submitButton).toBeDisabled()
-    // hit enter to ensure only one submit happens
-    userEvent.type(emailInput, "{enter}")
+    // hit enter to ensure no extra request is fired
+    userEvent.keyboard("{enter}")
 
     // confirmation message displayed instead of form
     await screen.findByRole("heading", { name: /email sent/i })
@@ -103,11 +101,7 @@ describe("ResetPassword", () => {
         throw Error(errorMessage)
       })
 
-    render(
-      <BrowserRouter>
-        <ResetPassword />
-      </BrowserRouter>,
-    )
+    render(component)
     userEvent.type(screen.getByLabelText(/email/i), `${email}{enter}`)
 
     // error message displayed in alert


### PR DESCRIPTION
# Add Tests for Login and Register

## Description

Added tests for the `Login` and `Register` components. Also made some minor updates to the `ResetPassword` tests.

Obviously there's no need for me to test that Firebase itself works as expected, so these tests focus on ensuring that the account management widgets:
- correctly enable/disable functionality
- call the correct auth methods with the correct payloads
- handle errors

Automatically rerouting to the logged in route is handled by hooks in `AccountApp` so there was no need to ensure that the redirect happens on success (whether accessing an existing account or creating a new one).