### PR TITLE
Refactor Accounts Logic

### DIFF
--- a/src/features/account/Login.tsx
+++ b/src/features/account/Login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 
 import LoadingButton from "@mui/lab/LoadingButton"
@@ -13,8 +13,11 @@ import { validateAccountForm } from "../../utils/formValidators"
 import { extractErrorMessage } from "../../utils/parsers"
 
 export default function Login() {
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
+  const [values, setValues] = useState({
+    email: "",
+    password: "",
+  })
+  const { email, password } = values
   const [inputErrors, setInputErrors] = useState<
     ReturnType<typeof validateAccountForm>
   >({})
@@ -23,7 +26,7 @@ export default function Login() {
 
   useEffect(() => {
     setInputErrors({})
-  }, [email, password])
+  }, [values])
 
   return (
     <Form error={authError} hideError={() => setAuthError("")} onSubmit={login}>
@@ -32,14 +35,16 @@ export default function Login() {
         error={Boolean(inputErrors.email)}
         helperText={inputErrors.email}
         label="Email"
-        onChange={e => setEmail(e.target.value)}
+        name="email"
+        onChange={handleChange}
         value={email}
       />
       <Password
         error={Boolean(inputErrors.password)}
         helperText={inputErrors.password}
         label="Password"
-        onChange={e => setPassword(e.target.value)}
+        name="password"
+        onChange={handleChange}
         value={password}
       />
       <LoadingButton loading={isSubmitting} type="submit" variant="contained">
@@ -52,17 +57,23 @@ export default function Login() {
       >
         Login with Google
       </LoadingButton>
-      <MuiLink component={Link} to="../reset-password">
+      <MuiLink component={Link} to={isSubmitting ? "#" : "../reset-password"}>
         Forgot Password
       </MuiLink>
       <Box mt={-3}>
         Don't have an account?{" "}
-        <MuiLink component={Link} to="../register">
+        <MuiLink component={Link} to={isSubmitting ? "#" : "../register"}>
           Register
         </MuiLink>
       </Box>
     </Form>
   )
+
+  function handleChange({
+    target: { name, value },
+  }: ChangeEvent<HTMLInputElement>) {
+    setValues({ ...values, [name]: value })
+  }
 
   async function googleLogin() {
     if (isSubmitting) return
@@ -78,7 +89,7 @@ export default function Login() {
 
   async function login() {
     if (isSubmitting) return
-    const inputErrors = validateAccountForm({ email, password })
+    const inputErrors = validateAccountForm(values)
     setInputErrors(inputErrors)
     if (Object.keys(inputErrors).length > 0) return
     setIsSubmitting(true)

--- a/src/features/account/Register.tsx
+++ b/src/features/account/Register.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 
 import LoadingButton from "@mui/lab/LoadingButton"
@@ -13,9 +13,12 @@ import { validateAccountForm } from "../../utils/formValidators"
 import { extractErrorMessage } from "../../utils/parsers"
 
 export default function Register() {
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
+  const [values, setValues] = useState({
+    email: "",
+    password: "",
+    username: "",
+  })
+  const { email, password, username } = values
   const [inputErrors, setInputErrors] = useState<
     ReturnType<typeof validateAccountForm>
   >({})
@@ -24,7 +27,7 @@ export default function Register() {
 
   useEffect(() => {
     setInputErrors({})
-  }, [email, name, password])
+  }, [values])
 
   return (
     <Form
@@ -34,24 +37,27 @@ export default function Register() {
     >
       <TextField
         autoFocus
-        error={Boolean(inputErrors.name)}
-        helperText={inputErrors.name}
+        error={Boolean(inputErrors.username)}
+        helperText={inputErrors.username}
         label="Username"
-        onChange={e => setName(e.target.value)}
-        value={name}
+        name="username"
+        onChange={handleChange}
+        value={username}
       />
       <TextField
         error={Boolean(inputErrors.email)}
         helperText={inputErrors.email}
         label="Email"
-        onChange={e => setEmail(e.target.value)}
+        name="email"
+        onChange={handleChange}
         value={email}
       />
       <Password
         error={Boolean(inputErrors.password)}
         helperText={inputErrors.password}
         label="Password"
-        onChange={e => setPassword(e.target.value)}
+        name="password"
+        onChange={handleChange}
         value={password}
       />
       <LoadingButton loading={isSubmitting} type="submit" variant="contained">
@@ -66,12 +72,18 @@ export default function Register() {
       </LoadingButton>
       <Box>
         Already have an account?{" "}
-        <MuiLink component={Link} to="../login">
+        <MuiLink component={Link} to={isSubmitting ? "#" : "../login"}>
           Login
         </MuiLink>
       </Box>
     </Form>
   )
+
+  function handleChange({
+    target: { name, value },
+  }: ChangeEvent<HTMLInputElement>) {
+    setValues({ ...values, [name]: value })
+  }
 
   async function googleLogin() {
     if (isSubmitting) return
@@ -87,12 +99,12 @@ export default function Register() {
 
   async function register() {
     if (isSubmitting) return
-    const inputErrors = validateAccountForm({ email, name, password })
+    const inputErrors = validateAccountForm(values)
     setInputErrors(inputErrors)
     if (Object.keys(inputErrors).length > 0) return
     setIsSubmitting(true)
     try {
-      await registerWithEmail(name, email, password)
+      await registerWithEmail(username, email, password)
     } catch (error) {
       setAuthError(extractErrorMessage(error))
     } finally {

--- a/src/features/account/ResetPassword.tsx
+++ b/src/features/account/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 
 import LoadingButton from "@mui/lab/LoadingButton"
@@ -13,7 +13,10 @@ import { validateAccountForm } from "../../utils/formValidators"
 import { extractErrorMessage } from "../../utils/parsers"
 
 export default function ResetPassword() {
-  const [email, setEmail] = useState("")
+  const [values, setValues] = useState({
+    email: "",
+  })
+  const { email } = values
   const [inputErrors, setInputErrors] = useState<
     ReturnType<typeof validateAccountForm>
   >({})
@@ -23,7 +26,7 @@ export default function ResetPassword() {
 
   useEffect(() => {
     setInputErrors({})
-  }, [email])
+  }, [values])
 
   if (wasEmailSent)
     return (
@@ -49,7 +52,8 @@ export default function ResetPassword() {
         error={Boolean(inputErrors.email)}
         helperText={inputErrors.email}
         label="Email"
-        onChange={e => setEmail(e.target.value)}
+        name="email"
+        onChange={handleChange}
         value={email}
       />
       <LoadingButton loading={isSubmitting} type="submit" variant="contained">
@@ -57,16 +61,22 @@ export default function ResetPassword() {
       </LoadingButton>
       <Box>
         Don't have an account?{" "}
-        <MuiLink component={Link} to="../register">
+        <MuiLink component={Link} to={isSubmitting ? "#" : "../register"}>
           Register
         </MuiLink>
       </Box>
     </Form>
   )
 
+  function handleChange({
+    target: { name, value },
+  }: ChangeEvent<HTMLInputElement>) {
+    setValues({ ...values, [name]: value })
+  }
+
   async function resetPassword() {
     if (isSubmitting) return
-    const inputErrors = validateAccountForm({ email })
+    const inputErrors = validateAccountForm(values)
     setInputErrors(inputErrors)
     if (Object.keys(inputErrors).length > 0) return
     setIsSubmitting(true)

--- a/src/features/account/tests/AccountApp.test.tsx
+++ b/src/features/account/tests/AccountApp.test.tsx
@@ -1,0 +1,63 @@
+import { BrowserRouter } from "react-router-dom"
+
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import AccountApp from "../AccountApp"
+
+const firebaseAuthHook = require("react-firebase-hooks/auth")
+
+jest.mock("react-firebase-hooks/auth", () => {
+  return {
+    // our default will be a null user
+    useAuthState: () => [null],
+  }
+})
+
+const mockUseNavigate = jest.fn()
+jest.mock("react-router-dom", () => {
+  const actualReactRouter = jest.requireActual("react-router-dom")
+  return {
+    ...actualReactRouter,
+    useNavigate: () => {
+      return (...args: unknown[]) => mockUseNavigate(...args)
+    },
+  }
+})
+
+describe("AccountApp", () => {
+  test("allows logged out user to access account routes", () => {
+    render(<AccountApp />, { wrapper: BrowserRouter })
+
+    // login is the default route
+    screen.getByRole("button", { name: "Login" })
+
+    // navigate to password reset from login
+    userEvent.click(screen.getByRole("link", { name: /forgot password/i }))
+    screen.getByRole("button", { name: /reset password/i })
+
+    // navigate to register from password reset
+    userEvent.click(screen.getByRole("link", { name: /register/i }))
+    screen.getByRole("button", { name: "Register" })
+
+    // navigate to login from register
+    userEvent.click(screen.getByRole("link", { name: /login/i }))
+    screen.getByRole("button", { name: "Login" })
+
+    // navigate to register from login
+    userEvent.click(screen.getByRole("link", { name: /register/i }))
+    screen.getByRole("button", { name: "Register" })
+  })
+
+  test("redirects to the home page if a user is logged in", () => {
+    jest.spyOn(firebaseAuthHook, "useAuthState").mockImplementation(() => {
+      // simulate that the hook returns a user
+      return [{ uid: "someId" }]
+    })
+    render(<AccountApp />, { wrapper: BrowserRouter })
+
+    // because there's a user we should redirect to the root route
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1)
+    expect(mockUseNavigate).toHaveBeenCalledWith("/")
+  })
+})

--- a/src/features/account/tests/utils.ts
+++ b/src/features/account/tests/utils.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker"
+
+export const email = faker.internet.email()
+export const errorMessage = faker.lorem.sentence(5)
+export const errorMessage2 = faker.lorem.sentence(4)
+export const invalidEmail = faker.lorem.word(5)
+export const invalidPassword = faker.lorem.word(5)
+export const password = faker.lorem.word(6)
+export const username = faker.internet.userName()

--- a/src/utils/formValidators.ts
+++ b/src/utils/formValidators.ts
@@ -2,33 +2,34 @@ import { hasChars, isEmail } from "./validators"
 
 interface InputValues {
   email?: string
-  name?: string
   password?: string
+  username?: string
 }
 interface InputErrors {
   email?: string
-  name?: string
   password?: string
+  username?: string
 }
-export function validateAccountForm({ email, name, password }: InputValues) {
+export function validateAccountForm(inputValues: InputValues) {
+  const { email, password, username } = inputValues
   const inputErrors: InputErrors = {}
-  if (email !== undefined) {
+  if ("email" in inputValues) {
     if (!hasChars(email)) {
       inputErrors.email = "Email is required"
     } else if (!isEmail(email)) {
       inputErrors.email = "Invalid email"
     }
   }
-  if (password !== undefined) {
+  if ("password" in inputValues) {
     if (!hasChars(password)) {
       inputErrors.password = "Password is required"
     } else if (!hasChars(password, 6)) {
       inputErrors.password = "Minimum password length is 6"
     }
   }
-  if (name !== undefined) {
-    if (!hasChars(name)) {
-      inputErrors.name = "Username is required"
+  if ("username" in inputValues) {
+    if (!hasChars(username)) {
+      inputErrors.username = "Username is required"
     }
   }
   return inputErrors


### PR DESCRIPTION
# Test AccountApp, Refactor Login, Register, and ResetPassword

## Description

I disabled the navigation links in the accounts section during the loading state and updated the tests accordingly. Also tested the routing in `AccountApp`.

Before moving on I wanted to do a little cleanup of the accounts sections. Namely:

- adding a (gitignored) `.env.test.local` so that I can limit the firebase mocks in my tests to only the methods with actual bearing on the tests themselves
- adding a "name" to all inputs and a common method in each component for handling input updates - this is largely because I'm planning to incorporate e2e testing with cypress and having names will make that easier
- adding a `utils` file in the account tests folder, which I'll continue to do on a go-forward to reduce duplication and increase confidence by using shared mocks throughout related tests
- miscellaneous other minor changes which don't impact functionality but which I feel improve readability and extensibility