### PR TITLE
Google Auth Button

### DIFF
--- a/src/components/form/GoogleButton.tsx
+++ b/src/components/form/GoogleButton.tsx
@@ -1,0 +1,62 @@
+import { Dispatch, SetStateAction } from "react"
+
+import LoadingButton from "@mui/lab/LoadingButton"
+import Box from "@mui/material/Box"
+
+import { logInWithGoogle } from "../../firebase"
+
+interface GoogleButtonProps {
+  handleError: (error: unknown) => void
+  isSubmitting: boolean
+  setIsSubmitting: Dispatch<SetStateAction<boolean>>
+}
+
+export default function GoogleButton({
+  handleError,
+  isSubmitting,
+  setIsSubmitting,
+}: GoogleButtonProps) {
+  return (
+    <LoadingButton
+      loading={isSubmitting}
+      onClick={googleLogin}
+      sx={{
+        fontSize: "1rem",
+        textTransform: "none",
+        ":not(:disabled)": {
+          background: "white",
+          color: "rgb(68, 68, 68)",
+          ":hover": {
+            boxShadow: "0 0 3px 3px rgb(66 133 244 / 30%)",
+          },
+        },
+      }}
+      variant="outlined"
+    >
+      {!isSubmitting && (
+        <Box
+          alt="google logo"
+          component="img"
+          src={
+            "https://user-images.githubusercontent.com/51540371/" +
+            "209448811-2b88004b-4abd-4b68-9944-9d47b350a735.png"
+          }
+          sx={{ mr: 3, width: "1.5rem" }}
+        />
+      )}
+      Sign in with Google
+    </LoadingButton>
+  )
+
+  async function googleLogin() {
+    if (isSubmitting) return
+    setIsSubmitting(true)
+    try {
+      await logInWithGoogle()
+    } catch (error) {
+      handleError(error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+}

--- a/src/components/form/Password.tsx
+++ b/src/components/form/Password.tsx
@@ -24,7 +24,7 @@ export default function Password({ InputProps, ...props }: PasswordProps) {
               onClick={() => setIsPlainText(!isPlainText)}
               sx={{ ml: -1.5 }}
             >
-              {isPlainText ? <Visibility /> : <VisibilityOff />}
+              {isPlainText ? <VisibilityOff /> : <Visibility />}
             </IconButton>
           </InputAdornment>
         ),

--- a/src/features/account/AccountApp.tsx
+++ b/src/features/account/AccountApp.tsx
@@ -18,7 +18,7 @@ export default function AccountApp() {
   const [user] = useAuthState(auth)
 
   useEffect(() => {
-    if (user) navigate("/")
+    if (user) navigate("/", { replace: true })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user])
 

--- a/src/features/account/Login.tsx
+++ b/src/features/account/Login.tsx
@@ -7,8 +7,9 @@ import MuiLink from "@mui/material/Link"
 import TextField from "@mui/material/TextField"
 
 import Form from "../../components/form/Form"
+import GoogleButton from "../../components/form/GoogleButton"
 import Password from "../../components/form/Password"
-import { logInWithEmail, logInWithGoogle } from "../../firebase"
+import { logInWithEmail } from "../../firebase"
 import { validateAccountForm } from "../../utils/formValidators"
 import { extractErrorMessage } from "../../utils/parsers"
 
@@ -46,13 +47,7 @@ export default function Login() {
       <LoadingButton loading={isSubmitting} type="submit" variant="contained">
         Login
       </LoadingButton>
-      <LoadingButton
-        loading={isSubmitting}
-        onClick={googleLogin}
-        variant="contained"
-      >
-        Login with Google
-      </LoadingButton>
+      <GoogleButton {...{ handleError, isSubmitting, setIsSubmitting }} />
       <MuiLink component={Link} to={isSubmitting ? "#" : "../reset-password"}>
         Forgot Password
       </MuiLink>
@@ -72,16 +67,8 @@ export default function Login() {
     setInputErrors({})
   }
 
-  async function googleLogin() {
-    if (isSubmitting) return
-    setIsSubmitting(true)
-    try {
-      await logInWithGoogle()
-    } catch (error) {
-      setAuthError(extractErrorMessage(error))
-    } finally {
-      setIsSubmitting(false)
-    }
+  function handleError(error: unknown) {
+    setAuthError(extractErrorMessage(error))
   }
 
   async function login() {
@@ -93,7 +80,7 @@ export default function Login() {
     try {
       await logInWithEmail(email, password)
     } catch (error) {
-      setAuthError(extractErrorMessage(error))
+      handleError(error)
     } finally {
       setIsSubmitting(false)
     }

--- a/src/features/account/Login.tsx
+++ b/src/features/account/Login.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from "react"
+import { ChangeEvent, useState } from "react"
 import { Link } from "react-router-dom"
 
 import LoadingButton from "@mui/lab/LoadingButton"
@@ -23,10 +23,6 @@ export default function Login() {
   >({})
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [authError, setAuthError] = useState("")
-
-  useEffect(() => {
-    setInputErrors({})
-  }, [values])
 
   return (
     <Form error={authError} hideError={() => setAuthError("")} onSubmit={login}>
@@ -73,6 +69,7 @@ export default function Login() {
     target: { name, value },
   }: ChangeEvent<HTMLInputElement>) {
     setValues({ ...values, [name]: value })
+    setInputErrors({})
   }
 
   async function googleLogin() {

--- a/src/features/account/Register.tsx
+++ b/src/features/account/Register.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from "react"
+import { ChangeEvent, useState } from "react"
 import { Link } from "react-router-dom"
 
 import LoadingButton from "@mui/lab/LoadingButton"
@@ -24,10 +24,6 @@ export default function Register() {
   >({})
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [authError, setAuthError] = useState("")
-
-  useEffect(() => {
-    setInputErrors({})
-  }, [values])
 
   return (
     <Form
@@ -83,6 +79,7 @@ export default function Register() {
     target: { name, value },
   }: ChangeEvent<HTMLInputElement>) {
     setValues({ ...values, [name]: value })
+    setInputErrors({})
   }
 
   async function googleLogin() {

--- a/src/features/account/Register.tsx
+++ b/src/features/account/Register.tsx
@@ -7,8 +7,9 @@ import MuiLink from "@mui/material/Link"
 import TextField from "@mui/material/TextField"
 
 import Form from "../../components/form/Form"
+import GoogleButton from "../../components/form/GoogleButton"
 import Password from "../../components/form/Password"
-import { logInWithGoogle, registerWithEmail } from "../../firebase"
+import { registerWithEmail } from "../../firebase"
 import { validateAccountForm } from "../../utils/formValidators"
 import { extractErrorMessage } from "../../utils/parsers"
 
@@ -59,13 +60,7 @@ export default function Register() {
       <LoadingButton loading={isSubmitting} type="submit" variant="contained">
         Register
       </LoadingButton>
-      <LoadingButton
-        loading={isSubmitting}
-        onClick={googleLogin}
-        variant="contained"
-      >
-        Register with Google
-      </LoadingButton>
+      <GoogleButton {...{ handleError, isSubmitting, setIsSubmitting }} />
       <Box>
         Already have an account?{" "}
         <MuiLink component={Link} to={isSubmitting ? "#" : "../login"}>
@@ -82,16 +77,8 @@ export default function Register() {
     setInputErrors({})
   }
 
-  async function googleLogin() {
-    if (isSubmitting) return
-    setIsSubmitting(true)
-    try {
-      await logInWithGoogle()
-    } catch (error) {
-      setAuthError(extractErrorMessage(error))
-    } finally {
-      setIsSubmitting(false)
-    }
+  function handleError(error: unknown) {
+    setAuthError(extractErrorMessage(error))
   }
 
   async function register() {
@@ -103,7 +90,7 @@ export default function Register() {
     try {
       await registerWithEmail(username, email, password)
     } catch (error) {
-      setAuthError(extractErrorMessage(error))
+      handleError(error)
     } finally {
       setIsSubmitting(false)
     }

--- a/src/features/account/ResetPassword.tsx
+++ b/src/features/account/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from "react"
+import { ChangeEvent, useState } from "react"
 import { Link } from "react-router-dom"
 
 import LoadingButton from "@mui/lab/LoadingButton"
@@ -23,10 +23,6 @@ export default function ResetPassword() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [authError, setAuthError] = useState("")
   const [wasEmailSent, setWasEmailSent] = useState(false)
-
-  useEffect(() => {
-    setInputErrors({})
-  }, [values])
 
   if (wasEmailSent)
     return (
@@ -72,6 +68,7 @@ export default function ResetPassword() {
     target: { name, value },
   }: ChangeEvent<HTMLInputElement>) {
     setValues({ ...values, [name]: value })
+    setInputErrors({})
   }
 
   async function resetPassword() {

--- a/src/features/account/tests/AccountApp.test.tsx
+++ b/src/features/account/tests/AccountApp.test.tsx
@@ -58,6 +58,6 @@ describe("AccountApp", () => {
 
     // because there's a user we should redirect to the root route
     expect(mockUseNavigate).toHaveBeenCalledTimes(1)
-    expect(mockUseNavigate).toHaveBeenCalledWith("/")
+    expect(mockUseNavigate).toHaveBeenCalledWith("/", { replace: true })
   })
 })

--- a/src/features/account/tests/AccountApp.test.tsx
+++ b/src/features/account/tests/AccountApp.test.tsx
@@ -30,7 +30,7 @@ describe("AccountApp", () => {
     render(<AccountApp />, { wrapper: BrowserRouter })
 
     // login is the default route
-    screen.getByRole("button", { name: "Login" })
+    screen.getByRole("button", { name: /login/i })
 
     // navigate to password reset from login
     userEvent.click(screen.getByRole("link", { name: /forgot password/i }))
@@ -38,15 +38,15 @@ describe("AccountApp", () => {
 
     // navigate to register from password reset
     userEvent.click(screen.getByRole("link", { name: /register/i }))
-    screen.getByRole("button", { name: "Register" })
+    screen.getByRole("button", { name: /register/i })
 
     // navigate to login from register
     userEvent.click(screen.getByRole("link", { name: /login/i }))
-    screen.getByRole("button", { name: "Login" })
+    screen.getByRole("button", { name: /login/i })
 
     // navigate to register from login
     userEvent.click(screen.getByRole("link", { name: /register/i }))
-    screen.getByRole("button", { name: "Register" })
+    screen.getByRole("button", { name: /register/i })
   })
 
   test("redirects to the home page if a user is logged in", () => {

--- a/src/features/account/tests/Login.test.tsx
+++ b/src/features/account/tests/Login.test.tsx
@@ -77,7 +77,7 @@ describe("Login", () => {
   test("logs user in if credentials are valid", async () => {
     render(<Login />, { wrapper: BrowserRouter })
     const submitButton = screen.getByRole("button", {
-      name: "Login",
+      name: /login/i,
     })
     userEvent.type(screen.getByLabelText(/email/i), email)
     userEvent.type(screen.getByLabelText("Password"), password)
@@ -92,7 +92,7 @@ describe("Login", () => {
     expect(submitButton).toBeDisabled()
     expect(
       screen.getByRole("button", {
-        name: /login with google/i,
+        name: /sign in with google/i,
       }),
     ).toBeDisabled()
     // hit enter to ensure no extra request is fired
@@ -116,7 +116,7 @@ describe("Login", () => {
   test("opens popup to log user in using google", async () => {
     render(<Login />, { wrapper: BrowserRouter })
     const googleButton = screen.getByRole("button", {
-      name: /login with google/i,
+      name: /sign in with google/i,
     })
     userEvent.click(googleButton)
 
@@ -126,7 +126,7 @@ describe("Login", () => {
 
     // buttons disabled while submitting
     expect(googleButton).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Login" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /login/i })).toBeDisabled()
     // hit enter to ensure no extra request is fired
     userEvent.keyboard("{enter}")
 
@@ -159,7 +159,9 @@ describe("Login", () => {
     screen.getByText(errorMessage)
 
     // test Google error handling
-    userEvent.click(screen.getByRole("button", { name: /login with google/i }))
+    userEvent.click(
+      screen.getByRole("button", { name: /sign in with google/i }),
+    )
     await screen.findByText(errorMessage2)
 
     // user can hide alert

--- a/src/features/account/tests/Register.test.tsx
+++ b/src/features/account/tests/Register.test.tsx
@@ -85,7 +85,7 @@ describe("Register", () => {
   test("logs user in if credentials are valid", async () => {
     render(<Register />, { wrapper: BrowserRouter })
     const submitButton = screen.getByRole("button", {
-      name: "Register",
+      name: /register/i,
     })
     userEvent.type(screen.getByLabelText(/username/i), username)
     userEvent.type(screen.getByLabelText(/email/i), email)
@@ -99,7 +99,7 @@ describe("Register", () => {
     expect(submitButton).toBeDisabled()
     expect(
       screen.getByRole("button", {
-        name: /register with google/i,
+        name: /sign in with google/i,
       }),
     ).toBeDisabled()
     // hit enter to ensure no extra request is fired
@@ -123,7 +123,7 @@ describe("Register", () => {
   test("opens popup to log user in using google", async () => {
     render(<Register />, { wrapper: BrowserRouter })
     const googleButton = screen.getByRole("button", {
-      name: /register with google/i,
+      name: /sign in with google/i,
     })
     userEvent.click(googleButton)
 
@@ -134,7 +134,7 @@ describe("Register", () => {
 
     // buttons disabled while submitting
     expect(googleButton).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Register" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /register/i })).toBeDisabled()
     // hit enter to ensure no extra request is fired
     userEvent.keyboard("{enter}")
 
@@ -169,7 +169,7 @@ describe("Register", () => {
 
     // test Google error handling
     userEvent.click(
-      screen.getByRole("button", { name: /register with google/i }),
+      screen.getByRole("button", { name: /sign in with google/i }),
     )
     await screen.findByText(errorMessage2)
 


### PR DESCRIPTION
# Create "Sign in with Google" Button Component

## Description

Created a new button which signs the user in using Google (creating a new account if necessary). Mostly just to make it look more official and legitimate but also because it reduces code duplication. The same button can be used in both the `/login` and `/register` forms. It looks the same in light and dark mode aside from the loading state:

**Dark Mode**
![google-button](https://user-images.githubusercontent.com/51540371/209448132-acf182fd-4b51-49f4-83c4-4a0cf77bd889.gif)

**Light Mode**
![google-button_light-mode](https://user-images.githubusercontent.com/51540371/209448311-993a30e1-5fdb-40cb-88ca-2a7f16dee450.gif)

Also snuck in a few very minor updates to accounts features (I realized that I should be replacing the `accounts` route whenever the user is logged in, and also that I can use the `handleChange` method of the accounts forms to clear the field validation instead of a useEffect). I've reversed the eye icons in the password component as well.